### PR TITLE
Add account owner and PDA validation to vote and execute instructions

### DIFF
--- a/src/instructions/execute_transaction.rs
+++ b/src/instructions/execute_transaction.rs
@@ -42,9 +42,6 @@ pub fn convert_accounts_to_refs<'a>(accounts: &'a [AccountInfo]) -> Result<Accou
     })
 }
 
-// @audit what if we pass fake transaction acc that has valid index,len but with bad data in it , we can then execute the transaction
-// with valid proposal acc, multisig acc
-// @audit we can pass proposal acc multiple times with valid+another transaction acc
 pub fn process_execute_transaction_instruction(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let [payer, multisig, proposal, transaction, rent, _system_program, _remaining @ ..] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys)

--- a/src/instructions/execute_transaction.rs
+++ b/src/instructions/execute_transaction.rs
@@ -51,16 +51,6 @@ pub fn process_execute_transaction_instruction(accounts: &[AccountInfo], data: &
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    if multisig.owner() != &crate::ID {
-        return Err(ProgramError::IllegalOwner);
-    }
-    if proposal.owner() != &crate::ID {
-        return Err(ProgramError::IllegalOwner);
-    }
-    if transaction.owner() != &crate::ID {
-        return Err(ProgramError::IllegalOwner);
-    }
-
     if multisig.data_is_empty() || proposal.data_is_empty() || transaction.data_is_empty() {
         return Err(ProgramError::InvalidAccountData);
     }

--- a/src/instructions/vote.rs
+++ b/src/instructions/vote.rs
@@ -49,13 +49,6 @@ pub fn process_vote_instruction(accounts: &[AccountInfo], data: &[u8]) -> Progra
     };
     let ix_data = VoteIxData::from_bytes(data)?;
 
-    if multisig_account.owner() != &crate::ID {
-        return Err(ProgramError::IllegalOwner);
-    }
-    if proposal_account.owner() != &crate::ID {
-        return Err(ProgramError::IllegalOwner);
-    }
-
     let multisig_header = MultisigState::from_account_info(multisig_account)?;
     let derived_multisig = pinocchio_pubkey::derive_address(
         &[MultisigState::SEED.as_bytes(), &multisig_header.primary_seed.to_le_bytes()],


### PR DESCRIPTION
### Summary
Adds validation to ensure that both the proposal and multisig accounts are owned by the program and that their PDAs are correctly derived.  
This prevents execution or voting using foreign proposals or fake PDAs.

### Changes
- Added account owner checks for `multisig`, `proposal`, and `transaction` accounts.
- Added `ProposalState::validate_pda` in both `vote` and `execute_transaction` instructions.
- Prevents executing a proposal that doesn't belong to the given multisig.
